### PR TITLE
Center the text body for better readability 

### DIFF
--- a/pages/_youtube-video.xnode
+++ b/pages/_youtube-video.xnode
@@ -1,3 +1,3 @@
-<div class="centered">
+<div class="centered youtube-wrapper">
 	<iframe class="youtube-video" width="#{attributes.fetch('width', 960)}" height="#{attributes.fetch('height', 540)}" src="https://www.youtube.com/embed/#{attributes[:id]}" frameborder="0" allowfullscreen></iframe>
 </div>

--- a/public/_static/page.css
+++ b/public/_static/page.css
@@ -17,6 +17,12 @@ main {
 	padding: 1rem;
 }
 
+article, div#comments {
+	max-width: 45em;
+	margin-left: auto;
+	margin-right: auto;
+}
+
 p, figure, dl, ul {
 	margin: 1rem 0;
 }

--- a/public/_static/page.css
+++ b/public/_static/page.css
@@ -571,7 +571,22 @@ li.locale {
 	padding-left: 1.25rem;
 }
 
-/* Resize the video based on the screen width: */
+.youtube-wrapper {
+	position: relative;
+	padding-bottom: 56.25%; /* 16:9 aspect ratio */
+	height: 0;
+	width 100%;
+}
+
+.youtube-video {
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+}
+
+/* Resize the video based on the screen width:
 .youtube-video {
 	width: 120rem;
 	height: 67.5rem;
@@ -596,4 +611,4 @@ li.locale {
 		width: 40rem;
 		height: 22.5rem;
 	}
-}
+}*/

--- a/public/_static/page.css
+++ b/public/_static/page.css
@@ -571,6 +571,7 @@ li.locale {
 	padding-left: 1.25rem;
 }
 
+/* Make youtube videos retain their 16:9 aspect ratio as they scale */
 .youtube-wrapper {
 	position: relative;
 	padding-bottom: 56.25%; /* 16:9 aspect ratio */
@@ -585,30 +586,4 @@ li.locale {
 	width: 100%;
 	height: 100%;
 }
-
-/* Resize the video based on the screen width:
-.youtube-video {
-	width: 120rem;
-	height: 67.5rem;
-}
-
-@media only screen and (max-width: 126.25rem) {
-	.youtube-video {
-		width: 80rem;
-		height: 45rem;
-	}
-}
-
-@media only screen and (max-width: 86.25rem) {
-	.youtube-video {
-		width: 60rem;
-		height: 33.75rem;
-	}
-}
-
-@media only screen and (max-width: 66.25rem) {
-	.youtube-video {
-		width: 40rem;
-		height: 22.5rem;
-	}
-}*/
+/* end youtube video stuff */


### PR DESCRIPTION
It is a good idea to limit how wide blocks of text can spread out. Having long lines (relative to font size) makes it difficult to focus on the text as it's more difficult to determine where a line starts and ends. Furthermore this makes the reader much more likely to lose track of which line comes next when returning from the end of the last line they've read. In my experience the sweet spot is usually somewhere between 40 and 60 `em` for body text, I set it to 45. The copy of Player Piano that was sitting on my desk has paragraphs that are 95mm wide and the 'm' character is about 5mm across so its body text is 46 `em` wide.

The other thing I did is make `iframe` videos continuously responsive it's bit of a hack exploiting how specifying `padding-bottom` as a percentage behaves, but there is just no better way of making `iframe` videos properly responsive. This was necessary to make the videos fit inside the `article` tags.