### PR TITLE
Improve progress report presentation

### DIFF
--- a/pages/_heading.xnode
+++ b/pages/_heading.xnode
@@ -1,11 +1,11 @@
 <?r
 document.attributes[:title] ||= content
-subtitle = attributes[:subtitle]
+summary = attributes[:summary]
 ?>
 <header id="header">
 	<h1><utopia:content/></h1>
-	<?r if subtitle && !subtitle.empty? ?>
-		<p class="subtitle">#{subtitle}</p>
+	<?r if summary && !summary.empty? ?>
+		<p class="summary">#{summary}</p>
 	<?r end ?>
 	<content:navigation/>
 </header>

--- a/pages/journal/2019-11/open-source-progress-report/index.en.xnode
+++ b/pages/journal/2019-11/open-source-progress-report/index.en.xnode
@@ -1,5 +1,5 @@
 <content:entry>
-	<p>This month <a href="https://github.com/ioquatix?tab=overview&amp;from=2019-11-01&amp;to=2019-11-30">has been productive</a>. I travelled to Japan to give a talk at RubyWorld Conference 2019 and attend a Ruby developer meeting. I was able to dedicate time to many important Ruby gems, and additionally some side projects.</p>
+	<p>This open source progress report covers <a href="https://github.com/ioquatix?tab=overview&amp;from=2019-11-01&amp;to=2019-11-30">work completed in November 2019</a>, when a RubyWorld Conference talk about asynchronous Ruby led to practical thread-safety fixes across the ecosystem and deeper discussions about Ruby 3 concurrency.</p>
 	
 	<h2 id="rubyworld-conference-2019-asynchronous-ruby">RubyWorld Conference 2019: Asynchronous Ruby</h2>
 	

--- a/pages/journal/2019-11/open-source-progress-report/links.yaml
+++ b/pages/journal/2019-11/open-source-progress-report/links.yaml
@@ -2,7 +2,7 @@ index:
   author: "Samuel Williams"
   created: 2019-11-30
   title: "Making Ruby Concurrency Safer"
-  summary: "November 2019 connected practical thread-safety fixes with work on Ruby concurrency, OpenSSL, Rack, and Faraday."
+  summary: "An Open Source Progress Report about practical thread-safety fixes, Ruby concurrency, OpenSSL, Rack, and Faraday."
   display: true
   front: true
 index.ja:

--- a/pages/journal/2019-11/open-source-progress-report/links.yaml
+++ b/pages/journal/2019-11/open-source-progress-report/links.yaml
@@ -1,7 +1,8 @@
 index:
   author: "Samuel Williams"
   created: 2019-11-30
-  summary: An overview of my Open Source work for November, 2019.
+  title: "Making Ruby Concurrency Safer"
+  summary: "November 2019 connected practical thread-safety fixes with work on Ruby concurrency, OpenSSL, Rack, and Faraday."
   display: true
   front: true
 index.ja:

--- a/pages/journal/2019-12/links.yaml
+++ b/pages/journal/2019-12/links.yaml
@@ -7,6 +7,7 @@ ruby-concurrency-progress-report:
 open-source-progress-report:
   author: "Samuel Williams"
   created: 2019-12-31
-  summary: An overview of my Open Source work for December, 2019.
+  title: "Laying the Groundwork for Ruby 3 Concurrency"
+  summary: "December 2019 advanced Ruby's scheduler hooks, Falcon production deployment, process metrics, and reusable Async connection pools."
   display: true
   front: true

--- a/pages/journal/2019-12/links.yaml
+++ b/pages/journal/2019-12/links.yaml
@@ -1,13 +1,14 @@
 ruby-concurrency-progress-report:
   author: "Samuel Williams"
   created: 2019-12-10
-  summary: An overview of my discussions with Matz and Koichi about Ruby concurrency.
+  title: "Separating Concurrency from Parallelism in Ruby"
+  summary: "A Ruby Concurrency Progress Report exploring fibers for cooperative concurrency, isolates for parallelism, and VM hooks connecting native I/O to event loops."
   display: true
   front: true
 open-source-progress-report:
   author: "Samuel Williams"
   created: 2019-12-31
   title: "Laying the Groundwork for Ruby 3 Concurrency"
-  summary: "December 2019 advanced Ruby's scheduler hooks, Falcon production deployment, process metrics, and reusable Async connection pools."
+  summary: "An Open Source Progress Report about Ruby scheduler hooks, Falcon production deployment, process metrics, and reusable Async connection pools."
   display: true
   front: true

--- a/pages/journal/2019-12/open-source-progress-report/index.xnode
+++ b/pages/journal/2019-12/open-source-progress-report/index.xnode
@@ -1,5 +1,5 @@
 <content:entry>
-	<p>This month <a href="https://github.com/ioquatix?tab=overview&amp;from=2019-12-01&amp;to=2019-12-31">has been productive</a>. I have been recovering from 6 weeks of travelling in Japan, and I've had to focus more on commercial work, however I was still able to continue development on my open source projects.</p>
+	<p>This open source progress report covers <a href="https://github.com/ioquatix?tab=overview&amp;from=2019-12-01&amp;to=2019-12-31">work completed in December 2019</a>, spanning Ruby's emerging scheduler interface, Falcon production deployment, better process-memory measurements, and reusable connection pooling for Async clients.</p>
 	
 	<h2>Ruby 2.7</h2>
 	

--- a/pages/journal/2019-12/ruby-concurrency-progress-report/index.xnode
+++ b/pages/journal/2019-12/ruby-concurrency-progress-report/index.xnode
@@ -1,5 +1,9 @@
 <content:entry>
-	<p>Last month I was able to spend some time discussing the concurrency model for Ruby 3 with Matz and Koichi. This progress report is a combination of both discussions.</p>
+	<p>Ruby had distinct tools for parallel execution and concurrent I/O, but their responsibilities were easy to conflate. Threads exposed shared mutable state and non-determinism, while fiber-based event loops required applications to replace Ruby's native I/O objects with library-specific wrappers.</p>
+	
+	<p>This Ruby Concurrency Progress Report records design discussions with Matz and Koichi about separating those concerns: isolates for parallelism, fibers for cooperative concurrency, and lightweight VM hooks through which native I/O could cooperate with an event loop.</p>
+	
+	<p><em>Historical note:</em> The <code class="language-ruby">Isolate</code> API shown here was exploratory; Ruby 3 ultimately introduced <a href="https://docs.ruby-lang.org/en/3.0/Ractor.html"><code class="language-ruby">Ractor</code></a> for parallel execution. The scheduler work developed into Ruby's <a href="https://docs.ruby-lang.org/en/3.0/Fiber/SchedulerInterface.html">Fiber Scheduler interface</a>.</p>
 	
 	<h2>Concurrency and Parallelism</h2>
 	

--- a/pages/journal/2020-01/links.yaml
+++ b/pages/journal/2020-01/links.yaml
@@ -1,7 +1,8 @@
 ruby-concurrency-progress-report:
   author: "Samuel Williams"
   created: 2020-01-14
-  summary: A progress report for the Ruby Association Grant 2019.
+  title: "Making Ruby I/O Work with Event Loops"
+  summary: "A Ruby Concurrency Progress Report introducing a prototype Scheduler that lets native Ruby I/O cooperate with fiber-based event loops."
   display: true
   front: true
   preview_url: preview.png
@@ -9,7 +10,7 @@ open-source-progress-report:
   author: "Samuel Williams"
   created: 2020-01-31
   title: "Modernizing Rack and Falcon Deployment"
-  summary: "January 2020 brought long-awaited Rack releases, Falcon production deployment commands, and new programming education resources."
+  summary: "An Open Source Progress Report about Rack maintenance, Falcon production deployment commands, and programming education resources."
   display: true
   front: true
   preview_url: rack.png

--- a/pages/journal/2020-01/links.yaml
+++ b/pages/journal/2020-01/links.yaml
@@ -8,7 +8,8 @@ ruby-concurrency-progress-report:
 open-source-progress-report:
   author: "Samuel Williams"
   created: 2020-01-31
-  summary: An overview of my Open Source work for January 2020.
+  title: "Modernizing Rack and Falcon Deployment"
+  summary: "January 2020 brought long-awaited Rack releases, Falcon production deployment commands, and new programming education resources."
   display: true
   front: true
   preview_url: rack.png

--- a/pages/journal/2020-01/open-source-progress-report/index.xnode
+++ b/pages/journal/2020-01/open-source-progress-report/index.xnode
@@ -1,5 +1,5 @@
 <content:entry>
-	<p><a href="https://github.com/ioquatix?tab=overview&amp;from=2020-01-01&amp;to=2020-01-31">January was productive</a>, with work spanning programming education, Rack maintenance, and a new Falcon release.</p>
+	<p>This open source progress report covers <a href="https://github.com/ioquatix?tab=overview&amp;from=2020-01-01&amp;to=2020-01-31">work completed in January 2020</a>, spanning programming education, long-awaited Rack releases, and new Falcon commands for production and virtual hosting.</p>
 	
 	<h2>Programming Dojo</h2>
 	

--- a/pages/journal/2020-01/ruby-concurrency-progress-report/index.xnode
+++ b/pages/journal/2020-01/ruby-concurrency-progress-report/index.xnode
@@ -1,7 +1,9 @@
 <content:entry>
-	<p>We have proven that fibers are useful for building scalable systems. In order to develop this further, we need to add hooks into the various Ruby VMs so that we can improve the concurrency of existing code without changes. There is an outstanding PR for this work, but additional effort is required to bring this to completion and show its effectiveness in real world situations. We propose to bring the existing PR to completion and improve Ruby’s concurrency model.</p>
+	<p>Fiber-based event loops could already run large numbers of concurrent tasks, but Ruby's native I/O methods did not know when or how to yield to them. Libraries such as Async therefore needed their own I/O wrappers, limiting how much existing Ruby code could benefit.</p>
 	
-	<p>This is the first progress report required by the 2019 Ruby Association Grant. There is one previous progress report: <a href="../../2019-12/ruby-concurrency-progress-report">December 2019</a>.</p>
+	<p>This Ruby Concurrency Progress Report introduces a VM-level <code class="language-ruby">Scheduler</code> interface and its first Async implementation. The scheduler gives operations such as <code class="language-ruby">IO#read</code>, <code class="language-ruby">IO#write</code>, and <code class="language-ruby">Kernel#sleep</code> a way to yield through the active event loop without changing the calling code.</p>
+	
+	<p>This was the first report required by the <a href="https://www.ruby.or.jp/en/news/20191031">2019 Ruby Association Grant</a>, following the earlier <a href="../../2019-12/ruby-concurrency-progress-report">design discussions from December 2019</a>.</p>
 	
 	<h2>Introduction</h2>
 	

--- a/pages/journal/2020-04/links.yaml
+++ b/pages/journal/2020-04/links.yaml
@@ -2,14 +2,15 @@ open-source-progress-report:
   author: "Samuel Williams"
   created: 2020-04-10
   title: "Running Falcon Virtual in Production"
-  summary: "February and March 2020 put Falcon Virtual into production, uncovered a Ruby socket vulnerability, and expanded work on thread safety and developer tooling."
+  summary: "An Open Source Progress Report about running Falcon Virtual in production, uncovering a Ruby socket vulnerability, and improving thread safety and developer tooling."
   display: true
   front: true
   preview_url: preview.png
 ruby-concurrency-final-report:
   author: "Samuel Williams"
   created: 2020-04-13
-  summary: The final report for the 2019 Ruby Association Grant.
+  title: "A Fiber Scheduler for Ruby"
+  summary: "The final Ruby Concurrency Progress Report presents a per-thread Fiber Scheduler and evaluates it with native Net::HTTP requests."
   display: true
   front: true
   preview_url: preview.png

--- a/pages/journal/2020-04/links.yaml
+++ b/pages/journal/2020-04/links.yaml
@@ -1,7 +1,8 @@
 open-source-progress-report:
   author: "Samuel Williams"
   created: 2020-04-10
-  summary: An overview of my Open Source work for February & March 2020.
+  title: "Running Falcon Virtual in Production"
+  summary: "February and March 2020 put Falcon Virtual into production, uncovered a Ruby socket vulnerability, and expanded work on thread safety and developer tooling."
   display: true
   front: true
   preview_url: preview.png

--- a/pages/journal/2020-04/open-source-progress-report/index.xnode
+++ b/pages/journal/2020-04/open-source-progress-report/index.xnode
@@ -1,5 +1,5 @@
 <content:entry>
-	<p>The past two months <a href="https://github.com/ioquatix?tab=overview&amp;from=2020-02-01&amp;to=2020-03-31">have been busy</a>. In New Zealand, we are in lockdown, so I have been adapting my work schedule and family life. Feel free to contact me if you would like to do some peer programming.</p>
+	<p>This open source progress report covers <a href="https://github.com/ioquatix?tab=overview&amp;from=2020-02-01&amp;to=2020-03-31">work completed in February and March 2020</a>. Running Falcon Virtual against production traffic drove improvements to HTTP/2 performance, prompted a new HTTP cache, and helped uncover a vulnerability in Ruby's socket library; the same period also produced new tools for deployment, task automation, and thread-safety analysis.</p>
 	
 	<h2>Falcon</h2>
 	

--- a/pages/journal/2020-04/ruby-concurrency-final-report/index.xnode
+++ b/pages/journal/2020-04/ruby-concurrency-final-report/index.xnode
@@ -1,7 +1,9 @@
 <content:entry>
-	<p>Ruby provides a mixed bag of tools for building asynchronous systems. While CRuby wraps all Ruby code in a Global Virtual Machine Lock (GVL), JRuby and TruffleRuby provide truly parallel threads. Code analysis reveals that thread synchronisation primitives are often used incorrectly, and while results may be okay on CRuby, running the same code on JRuby or TruffleRuby can expose race conditions with unexpected consequences. We present a light weight per-thread fiber scheduler which improves the concurrency of existing code with minimal changes. We discuss its implementation within Ruby and evaluate its performance using <code class="syntax ruby">Net::HTTP</code>.</p>
+	<p>Ruby's native I/O methods traditionally blocked the calling fiber, leaving event-loop libraries to provide replacement wrappers. This Ruby Concurrency Progress Report presents a lightweight per-thread Fiber Scheduler which lets those native operations cooperate with an event loop. It explains the implementation and evaluates the result using <code class="language-ruby">Net::HTTP</code>.</p>
 	
-	<p>This is the final report required by the 2019 Ruby Association Grant. There are two previous progress reports: <a href="../../2019-12/ruby-concurrency-progress-report/index">December 2019</a> and <a href="../../2020-01/ruby-concurrency-progress-report/index">January 2020</a>.</p>
+	<p>This was the final report required by the 2019 Ruby Association Grant, following reports on the <a href="../../2019-12/ruby-concurrency-progress-report/index">initial design discussions</a> and the <a href="../../2020-01/ruby-concurrency-progress-report/index">first scheduler prototype</a>.</p>
+	
+	<p><em>Historical note:</em> The interface described here was still experimental in April 2020. A version of the <a href="https://docs.ruby-lang.org/en/3.0/Fiber/SchedulerInterface.html">Fiber Scheduler interface</a> subsequently shipped with Ruby 3.0.</p>
 	
 	<h2>Introduction</h2>
 	

--- a/pages/journal/2020-06/links.yaml
+++ b/pages/journal/2020-06/links.yaml
@@ -2,7 +2,7 @@ open-source-progress-report:
   author: "Samuel Williams"
   created: 2020-06-14
   title: "Bringing Fiber Scheduling to Ruby"
-  summary: "April and May 2020 brought an experimental Fiber Scheduler to Ruby, alongside new work on Async, project documentation, and parallel testing."
+  summary: "An Open Source Progress Report about Ruby's experimental Fiber Scheduler, Async, task-oriented project documentation, and parallel testing."
   display: true
   front: true
   preview_url: preview.png

--- a/pages/journal/2020-06/links.yaml
+++ b/pages/journal/2020-06/links.yaml
@@ -1,7 +1,8 @@
 open-source-progress-report:
   author: "Samuel Williams"
   created: 2020-06-14
-  summary: An overview of my Open Source work for April & May 2020.
+  title: "Bringing Fiber Scheduling to Ruby"
+  summary: "April and May 2020 brought an experimental Fiber Scheduler to Ruby, alongside new work on Async, project documentation, and parallel testing."
   display: true
   front: true
   preview_url: preview.png

--- a/pages/journal/2020-06/open-source-progress-report/index.xnode
+++ b/pages/journal/2020-06/open-source-progress-report/index.xnode
@@ -1,5 +1,5 @@
 <content:entry>
-	<p>The past two months <a href="https://github.com/ioquatix?tab=overview&amp;from=2020-04-01&amp;to=2020-05-31">have been busy</a>. In New Zealand, we have just come out of lockdown, but the situation remains precarious.</p>
+	<p>This open source progress report covers <a href="https://github.com/ioquatix?tab=overview&amp;from=2020-04-01&amp;to=2020-05-31">work completed in April and May 2020</a>. The central milestone was the experimental Fiber Scheduler entering Ruby, supported by an Async implementation and accompanied by new work on sustainable maintenance, task-oriented documentation, and parallel test execution.</p>
 	
 	<h2>Light Weight Per-Thread Fiber Scheduler</h2>
 	

--- a/pages/journal/2026-08/links.yaml
+++ b/pages/journal/2026-08/links.yaml
@@ -2,7 +2,6 @@ open-source-progress-update:
   author: "Samuel Williams"
   created: 2026-08-01
   title: "Making Failure More Predictable in Ruby Systems"
-  subtitle: "Open Source Progress Update — July 2026"
   summary: "July 2026 focused on predictable failure handling, lower-memory MIME lookup, and load-aware Falcon clusters."
   display: true
   front: true

--- a/pages/journal/2026-08/links.yaml
+++ b/pages/journal/2026-08/links.yaml
@@ -2,7 +2,7 @@ open-source-progress-update:
   author: "Samuel Williams"
   created: 2026-08-01
   title: "Making Failure More Predictable in Ruby Systems"
-  summary: "July 2026 focused on predictable failure handling, lower-memory MIME lookup, and load-aware Falcon clusters."
+  summary: "An Open Source Progress Report about predictable failure handling, lower-memory MIME lookup, and load-aware Falcon clusters."
   display: true
   front: true
   preview_url: banner.webp

--- a/pages/journal/_entry.xnode
+++ b/pages/journal/_entry.xnode
@@ -10,7 +10,7 @@ next_links.reject!{|link| link[:display] == false}
 author = current_link[:author] || "Samuel Williams"
 created = current_link[:created] || File.ctime(parent.node.file_path)
 title = current_link.title
-subtitle = current_link[:subtitle]
+summary = current_link[:summary]
 
 preview_path = first.node.relative_path(current_link[:preview_url] || "preview.jpg")
 preview_url = request.base_url + preview_path
@@ -43,7 +43,7 @@ if prev_link == nil || next_link == nil
 end
 
 ?><content:page image_url="#{preview_url}">
-	<content:heading subtitle="#{subtitle}">#{title}</content:heading>
+	<content:heading summary="#{summary}">#{title}</content:heading>
 	
 	<main>
 		<header>

--- a/public/_static/page.css
+++ b/public/_static/page.css
@@ -96,7 +96,7 @@ nav li {
 	margin: 1rem 2rem;
 }
 
-#header .subtitle {
+#header .summary {
 	margin: -0.5rem 2rem 1rem;
 	font-size: 1rem;
 	line-height: 1.25;


### PR DESCRIPTION
## Summary

- use journal summaries as consistent subtext beneath article titles
- give older Open Source and Ruby Concurrency progress reports substantive titles and stronger summaries
- improve report introductions and add historical context for Ractor and Fiber Scheduler

## Validation

- validated edited articles as XML
- loaded all journal metadata as YAML
- ran `git diff --check`