### PR TITLE
Add “The Case of the Interrupt That Arrived Too Soon”

### DIFF
--- a/pages/journal/2026-08/links.yaml
+++ b/pages/journal/2026-08/links.yaml
@@ -17,3 +17,11 @@ the-case-of-the-readable-dead-connection:
   front: true
   preview_url: banner.png
   banner_url: banner.png
+
+the-case-of-the-interrupt-that-arrived-too-soon:
+  author: "Samuel Williams"
+  created: 2026-08-02
+  title: "The Case of the Interrupt That Arrived Too Soon: A Ruby Mystery"
+  summary: "Dr. Claude Watson investigates a narrow race between Ruby's pending-interrupt queue and an event selector entering a native wait."
+  display: true
+  front: true

--- a/pages/journal/2026-08/the-case-of-the-interrupt-that-arrived-too-soon/index.xnode
+++ b/pages/journal/2026-08/the-case-of-the-interrupt-that-arrived-too-soon/index.xnode
@@ -3,81 +3,119 @@
 	
 	<h2>Chapter I: The Worker Which Missed Its Cue</h2>
 	
-	<p>The Falcon worker had completed its request. The supervisor sent <code class="language-plain">SIGINT</code>, beginning the normal graceful-shutdown sequence. One worker cleaned up and exited. Another remained inside its event selector until the supervisor’s later escalation ended it.</p>
+	<p>The Falcon worker had completed its request when the supervisor sent <code class="language-plain">SIGINT</code>, beginning the normal graceful-shutdown sequence. One worker cleaned up and exited. Another remained inside its event selector until the supervisor’s later escalation ended it.</p>
 	
-	<p>This was not a general failure of Falcon shutdown. It was an intermittent delay which appeared only when the signal landed during a very small transition inside the event loop.</p>
+	<p>“The worker ignored the signal,” I declared.</p>
 	
-	<p>“The signal was delivered,” I said, studying the trace. “Why did the worker not act upon it?”</p>
+	<p>Holmes turned from the terminal. “What evidence would distinguish an ignored signal from a received signal awaiting delivery?”</p>
 	
-	<p>“Because delivery and action are not the same event,” Holmes replied.</p>
+	<p>The backtrace placed the delayed worker inside <code class="language-ruby">IO::Event::Selector::KQueue#select</code>. We sent a separate diagnostic signal to obtain another dump. The native wait returned, Ruby immediately noticed an already-pending <code class="language-ruby">Interrupt</code>, and the worker followed its cleanup path.</p>
 	
-	<p>The stuck worker’s backtrace placed it in <code class="language-ruby">IO::Event::Selector::KQueue#select</code>. Sending another diagnostic signal woke the native wait; Ruby then noticed the already-pending <code class="language-ruby">Interrupt</code> and followed the intended cleanup path.</p>
+	<p>“Then <code class="language-plain">SIGINT</code> was not lost,” I said. “Ruby had remembered it.”</p>
 	
-	<p>The interrupt had not been lost. The thread had gone to sleep at precisely the wrong moment.</p>
+	<p>“But the thread went to sleep before it could act upon that memory.”</p>
 	
-	<h2>Chapter II: Why Ruby Defers Interrupts</h2>
+	<p>This was not a general failure of Falcon shutdown. It was an intermittent delay which required a signal to land during a very small transition inside the event loop. Under a typical supervisor the worker would eventually receive <code class="language-plain">SIGKILL</code>; the mystery was why it occasionally missed the graceful path.</p>
 	
-	<p>Asynchronous exceptions can arrive between almost any two instructions. Raising one while a library is updating a queue, releasing a resource, or changing scheduler state can leave an invariant half-finished. Ruby therefore provides <code class="language-ruby">Thread.handle_interrupt</code>, which lets code defer selected exceptions until a controlled boundary.</p>
+	<h2>Chapter II: Why Not Raise Immediately?</h2>
 	
-	<p>Async uses that facility so signals request cancellation without tearing through internal synchronization at an arbitrary point. An earlier problem complicated this model: CRuby’s default <code class="language-plain">SIGINT</code> path raised <code class="language-ruby">Interrupt</code> directly instead of placing it in the thread’s pending-interrupt queue. <a href="https://bugs.ruby-lang.org/issues/22133">Bug #22133</a> and <a href="https://github.com/ruby/ruby/pull/17533">the corresponding Ruby fix</a> made the default signal respect <code class="language-ruby">Thread.handle_interrupt</code> like other asynchronous exceptions.</p>
+	<p>“If Ruby knows an <code class="language-ruby">Interrupt</code> is pending,” I asked, “why not raise it at once?”</p>
 	
-	<p>That correction made delivery predictable, but it also helped expose a second, subtler question: how should an event selector behave when a masked signal exception is pending?</p>
+	<p>Holmes opened a scheduler queue midway through an update. “What if it arrives here?”</p>
 	
-	<p>It must return control to Ruby. The exception may remain deferred, but the scheduler needs an opportunity to reach the boundary where shutdown is handled.</p>
+	<p>An asynchronous exception can appear between almost any two instructions. Raising it while a library is updating a queue, releasing a resource, or changing scheduler state can leave an invariant half-finished. Ruby therefore provides <code class="language-ruby">Thread.handle_interrupt</code>, allowing selected exceptions to be deferred until a controlled boundary.</p>
 	
-	<h2>Chapter III: The Check Before Sleep</h2>
+	<p>Async uses that facility so a signal requests cancellation without tearing through internal synchronization at an arbitrary point.</p>
 	
-	<p>An event selector such as <code class="language-plain">kqueue</code>, <code class="language-plain">epoll</code>, or <code class="language-plain">io_uring</code> may wait in the kernel with no timeout. While it waits, CRuby releases the Global VM Lock so other Ruby threads can run.</p>
+	<p>“So deferred does not mean discarded,” I said. “The exception waits in the thread’s pending-interrupt queue.”</p>
 	
-	<p>On older Ruby versions, <code class="language-ruby">IO::Event</code> tried to avoid sleeping with a queued exception by checking first:</p>
+	<p>“Precisely. The scheduler must continue running until it reaches the boundary where delivery is allowed.”</p>
+	
+	<p>An earlier inconsistency had complicated this design: CRuby’s default <code class="language-plain">SIGINT</code> path raised <code class="language-ruby">Interrupt</code> directly instead of using that queue. <a href="https://bugs.ruby-lang.org/issues/22133">Bug #22133</a> and <a href="https://github.com/ruby/ruby/pull/17533">the corresponding Ruby fix</a> made the default signal respect <code class="language-ruby">Thread.handle_interrupt</code> like other asynchronous exceptions.</p>
+	
+	<p>That gave us predictable deferral. It also made the selector’s responsibility clearer: a masked exception need not raise immediately, but it must prevent the scheduler from sleeping past the opportunity to handle it.</p>
+	
+	<h2>Chapter III: The Sensible Check</h2>
+	
+	<p>Event selectors such as <code class="language-plain">kqueue</code>, <code class="language-plain">epoll</code>, and <code class="language-plain">io_uring</code> may wait in the kernel without a timeout. CRuby releases the Global VM Lock around that wait so other Ruby threads can run.</p>
+	
+	<p>On older Ruby versions, <code class="language-ruby">IO::Event</code> checked for a queued exception before entering the native wait:</p>
 	
 	<content:listing brush="ruby">return unless Thread.pending_interrupt?</content:listing>
 	
-	<p>Conceptually, the sequence was:</p>
+	<p>“That appears sufficient,” I said. “If an interrupt is pending, do not sleep. Otherwise, sleep.”</p>
+	
+	<p>Holmes wrote the operations separately:</p>
 	
 	<content:listing brush="text">check Ruby's pending-interrupt queue
 release the GVL
 install the native unblock function
 enter kevent/epoll/io_uring wait</content:listing>
 	
-	<p>The check was sensible, but it was a separate operation. A signal could arrive after the check and be processed while Ruby transitioned into the no-GVL region. Because <code class="language-ruby">Thread.handle_interrupt</code> masked the resulting exception, Ruby queued it rather than raising it.</p>
+	<p>“At which line does this become one indivisible decision?” he asked.</p>
 	
-	<p>The selector could then begin its native wait without an unblock function having observed that earlier signal. No second operating-system signal was guaranteed to wake it.</p>
+	<p>It did not. A signal could arrive after <code class="language-ruby">Thread.pending_interrupt?</code> returned false but while Ruby was entering the no-GVL region. Ruby would process the signal, place the masked exception in the pending queue, and continue the transition.</p>
+	
+	<p>“But the signal should interrupt <code class="language-plain">kevent</code>,” I objected.</p>
+	
+	<p>“Only if the native wait has begun, or Ruby has installed the unblock function which can wake it. What if the signal is handled in the interval before either is true?”</p>
+	
+	<p>The exception could become pending too late for the preliminary check and too early to wake the native operation. The selector would then enter a wait with no second operating-system signal guaranteed to disturb it.</p>
 	
 	<h2>Chapter IV: Catching the Interval</h2>
 	
-	<p>The race resisted ordinary logging because instrumentation changed its timing. A stress reproduction ran many short Falcon worker lifecycles, sent <code class="language-plain">SIGINT</code> after a completed request, and dumped any worker which had not left promptly.</p>
+	<p>Our first attempts to observe the race changed its timing. Holmes reduced the experiment to many short Falcon worker lifecycles: complete one request, send <code class="language-plain">SIGINT</code>, and record any worker which did not leave promptly.</p>
 	
-	<p>Native instrumentation eventually recorded the decisive ordering on the compatibility path:</p>
+	<p>Native instrumentation eventually captured the ordering on the compatibility path:</p>
 	
 	<content:listing brush="text">pending-interrupt check: false
 signal SIGINT
 native callback entered, pending queue: true
 kevent(timeout: forever)</content:listing>
 	
-	<p>Moving the check closer to the no-GVL call did not close the gap. Across 2,000 iterations, workers could still hit it. The transition into <code class="language-c">rb_thread_call_without_gvl2</code> itself was a point where Ruby could process the signal.</p>
+	<p>“Then move the check immediately before <code class="language-c">rb_thread_call_without_gvl2</code>,” I said. “There will be almost no interval left.”</p>
 	
-	<p>“Then there is no correct place outside the door to check whether the room is occupied,” I said.</p>
+	<p>“Almost?” Holmes asked.</p>
 	
-	<p>“Exactly,” said Holmes. “The check and the act of locking the door must be one operation.”</p>
+	<p>We tried it. Across 2,000 iterations, the delay still appeared. Ruby could process the signal during the transition inside <code class="language-c">rb_thread_call_without_gvl2</code>, after any external predicate had returned.</p>
+	
+	<p>“The check is accurate,” I admitted. “The native wait is also behaving correctly. The bug belongs to the gap between two correct operations.”</p>
+	
+	<p>“And narrowing a race is not the same as closing it.”</p>
 	
 	<h2>Chapter V: An Atomic Doorway</h2>
 	
-	<p>CRuby needed an API which could inspect the pending queue as part of entering the no-GVL region. <a href="https://github.com/ruby/ruby/pull/17553">The new <code class="language-c">RB_NOGVL_PENDING_INTR_FAIL</code> flag</a> provides that contract.</p>
+	<p>“Then <code class="language-ruby">IO::Event</code> needs to hold a lock around its check and the no-GVL transition,” I proposed.</p>
 	
-	<p>When passed to <code class="language-c">rb_nogvl</code>, the flag says: if this thread already has pending interrupts, including masked ones, do not invoke the native blocking callback. Ruby performs the decision inside its own transition machinery, where it can coordinate the pending queue and the unblock function under the appropriate lock.</p>
+	<p>“Which lock protects Ruby’s pending-interrupt queue and the installation of its unblock function?”</p>
 	
-	<p>Instrumentation on Ruby with the new flag caught the race cleanly:</p>
+	<p>That state belonged to CRuby. An extension could ask whether an interrupt was pending, but it could not safely make that query atomic with Ruby’s internal transition.</p>
+	
+	<p>The solution was therefore a Ruby C API rather than another selector-side check. <a href="https://github.com/ruby/ruby/pull/17553">The new <code class="language-c">RB_NOGVL_PENDING_INTR_FAIL</code> flag</a> extends <code class="language-c">rb_nogvl</code> with a precise contract: if the current thread already has pending interrupts, including masked ones, do not invoke the native blocking callback.</p>
+	
+	<p>“So Ruby itself performs the test while entering the blocking region,” I said.</p>
+	
+	<p>“Yes. It can coordinate the pending queue and the unblock function under the lock which governs both.”</p>
+	
+	<p>Instrumentation on Ruby with the new flag caught the same timing without entering the native wait:</p>
 	
 	<content:listing brush="text">before transition: no pending interrupt
 signal SIGINT
 after transition: callback not entered, interrupt pending</content:listing>
 	
-	<p>The important result was not that <code class="language-ruby">Interrupt</code> suddenly raised inside a protected section. The selector returned control to Ruby, while the surrounding mask continued to determine when the exception could be delivered.</p>
+	<p>The selector returned control to Ruby. The surrounding <code class="language-ruby">Thread.handle_interrupt</code> mask still decided when the exception could be raised; the new flag prevented deferral from becoming accidental sleep.</p>
 	
-	<h2>Chapter VI: A Path for Released Rubies</h2>
+	<h2>Chapter VI: The Older-Ruby Problem</h2>
 	
-	<p>At the time of the investigation, the new C flag was available in Ruby’s development branch but not in released Ruby 4.0 versions. <code class="language-ruby">IO::Event</code> therefore needed both a preferred path for future Ruby and a safe compatibility path for existing installations.</p>
+	<p>“Case closed for the next Ruby release,” I said.</p>
+	
+	<p>Holmes indicated the installed Ruby 4.0 interpreter. “And what of the applications running today?”</p>
+	
+	<p>At the time of the investigation, the new flag existed in Ruby’s development branch but not in released Ruby 4.0 versions. <code class="language-ruby">IO::Event</code> needed a preferred native path for future Ruby and a safe compatibility path for existing installations.</p>
+	
+	<p>“Could the fallback poll with a short timeout?” I asked.</p>
+	
+	<p>“It would avoid an unbounded native wait, but every idle event loop would wake periodically. Can Ruby’s existing interrupt machinery refresh the state at the transition instead?”</p>
 	
 	<p><a href="https://github.com/socketry/io-event/pull/204">The <code class="language-ruby">IO::Event</code> fix</a> centralized native selector waits behind one helper:</p>
 	
@@ -86,23 +124,41 @@ after transition: callback not entered, interrupt pending</content:listing>
 	  <li>On older Ruby, it enters a C-backed <code class="language-ruby">Thread.handle_interrupt(SignalException =&gt; :never)</code> block immediately around <code class="language-c">rb_thread_call_without_gvl2</code>.</li>
 	</ol>
 	
-	<p>Pushing that inner mask refreshes Ruby’s pending-interrupt state. Because the block proceeds directly into the native transition without another Ruby safe point, Ruby either notices the pending exception before sleeping or installs the unblock function in time for a newly arriving signal to wake the selector. The outer Async mask still controls actual exception delivery.</p>
+	<p>“Why install another <code class="language-ruby">:never</code> mask when the signal is already masked?” I asked.</p>
 	
-	<p>The helper is shared by KQueue, EPoll, and URing, so the fix does not depend on the backend which happened to reveal the race.</p>
+	<p>“Because pushing the inner mask refreshes Ruby’s pending-interrupt state. The C-backed block then proceeds directly into the native transition without another Ruby safe point.”</p>
 	
-	<h2>Chapter VII: Proving a Negative</h2>
+	<p>Ruby either notices the pending exception before sleeping or installs the unblock function in time for a newly arriving signal to wake the selector. The outer Async mask continues to control delivery, so the compatibility path does not turn graceful cancellation into an exception at an arbitrary internal point.</p>
 	
-	<p>Timing bugs invite overconfident conclusions. A hundred successful runs prove little when the failure is rare. The validation therefore kept the original shutdown shape and increased the opportunities for the signal to strike the transition.</p>
+	<p>The helper serves KQueue, EPoll, and URing. KQueue revealed the race, but the violated rule concerned every backend entering a native wait.</p>
 	
-	<p>The compatibility implementation completed 2,000 iterations with two workers per iteration and no delayed worker dumps or shutdown failures. Focused selector tests exercised interrupts pending before a wait and arriving during it. A small KQueue benchmark found no measurable latency change; the older-Ruby fallback does allocate one internal object for each genuinely blocking wait, while Ruby with the native flag retains the direct path.</p>
+	<h2>Chapter VII: How Many Quiet Runs Are Enough?</h2>
 	
-	<p>The result should be stated narrowly. The change closes an obscure race in graceful shutdown. Before the fix, a worker which struck that interval would not remain alive without limit under a typical supervisor: escalation would eventually send <code class="language-plain">SIGKILL</code>. The value of the fix is that Ctrl-C and deployment termination can reliably take the graceful path instead of occasionally requiring that escalation.</p>
+	<p>The revised implementation survived a hundred iterations without delay.</p>
+	
+	<p>“A convincing result?” I asked.</p>
+	
+	<p>“How often did the original fail?” Holmes replied.</p>
+	
+	<p>“Rarely.”</p>
+	
+	<p>“Then a small quiet sample proves very little.”</p>
+	
+	<p>We kept the original shutdown shape and multiplied the opportunities for the signal to strike the transition. The compatibility implementation completed 2,000 iterations with two workers per iteration and no delayed worker dumps or shutdown failures. Focused selector tests covered interrupts pending before a wait and arriving during it.</p>
+	
+	<p>A KQueue benchmark found no measurable latency change. The older-Ruby fallback does allocate one internal object for each genuinely blocking wait; Ruby with the native flag retains the direct path. That is a concrete compatibility cost, rather than a claim that the workaround is free.</p>
+	
+	<p>“And we should not say the worker previously waited forever,” I added. “The supervisor would escalate to <code class="language-plain">SIGKILL</code>.”</p>
+	
+	<p>“Correct. State the result at its proper scale: an obscure race could delay graceful shutdown until escalation. The fix makes the intended cleanup path reliable.”</p>
 	
 	<h2>Epilogue: State and Sleep Must Agree</h2>
 	
-	<p>Concurrency defects often hide between operations which are individually correct. <code class="language-ruby">Thread.pending_interrupt?</code> answered its question accurately. The selector’s native wait behaved correctly. The failure lived in the interval between them.</p>
+	<p>“I trusted the pending-interrupt check because it always answered truthfully,” I said.</p>
 	
-	<p>Whenever one thread decides whether it is safe to sleep while another can publish work, cancellation, or an interrupt, the decision and the transition to sleep must share an atomic protocol. Checking first is not enough.</p>
+	<p>“It answered a question about one instant,” Holmes replied. “The selector acted in another.”</p>
+	
+	<p>Whenever one thread decides whether it is safe to sleep while another can publish work, cancellation, or an interrupt, the decision and the transition to sleep must share an atomic protocol. Correct observations composed without coordination can still produce an incorrect system.</p>
 	
 	<p>Holmes folded the timing trace and placed it in the casebook.</p>
 	

--- a/pages/journal/2026-08/the-case-of-the-interrupt-that-arrived-too-soon/index.xnode
+++ b/pages/journal/2026-08/the-case-of-the-interrupt-that-arrived-too-soon/index.xnode
@@ -1,0 +1,116 @@
+<content:entry>
+	<p><em>Being an account of a signal which arrived in the narrow interval between deciding to sleep and actually doing so, as recorded by Dr. Claude Watson.</em></p>
+	
+	<h2>Chapter I: The Worker Which Missed Its Cue</h2>
+	
+	<p>The Falcon worker had completed its request. The supervisor sent <code class="language-plain">SIGINT</code>, beginning the normal graceful-shutdown sequence. One worker cleaned up and exited. Another remained inside its event selector until the supervisor’s later escalation ended it.</p>
+	
+	<p>This was not a general failure of Falcon shutdown. It was an intermittent delay which appeared only when the signal landed during a very small transition inside the event loop.</p>
+	
+	<p>“The signal was delivered,” I said, studying the trace. “Why did the worker not act upon it?”</p>
+	
+	<p>“Because delivery and action are not the same event,” Holmes replied.</p>
+	
+	<p>The stuck worker’s backtrace placed it in <code class="language-ruby">IO::Event::Selector::KQueue#select</code>. Sending another diagnostic signal woke the native wait; Ruby then noticed the already-pending <code class="language-ruby">Interrupt</code> and followed the intended cleanup path.</p>
+	
+	<p>The interrupt had not been lost. The thread had gone to sleep at precisely the wrong moment.</p>
+	
+	<h2>Chapter II: Why Ruby Defers Interrupts</h2>
+	
+	<p>Asynchronous exceptions can arrive between almost any two instructions. Raising one while a library is updating a queue, releasing a resource, or changing scheduler state can leave an invariant half-finished. Ruby therefore provides <code class="language-ruby">Thread.handle_interrupt</code>, which lets code defer selected exceptions until a controlled boundary.</p>
+	
+	<p>Async uses that facility so signals request cancellation without tearing through internal synchronization at an arbitrary point. An earlier problem complicated this model: CRuby’s default <code class="language-plain">SIGINT</code> path raised <code class="language-ruby">Interrupt</code> directly instead of placing it in the thread’s pending-interrupt queue. <a href="https://bugs.ruby-lang.org/issues/22133">Bug #22133</a> and <a href="https://github.com/ruby/ruby/pull/17533">the corresponding Ruby fix</a> made the default signal respect <code class="language-ruby">Thread.handle_interrupt</code> like other asynchronous exceptions.</p>
+	
+	<p>That correction made delivery predictable, but it also helped expose a second, subtler question: how should an event selector behave when a masked signal exception is pending?</p>
+	
+	<p>It must return control to Ruby. The exception may remain deferred, but the scheduler needs an opportunity to reach the boundary where shutdown is handled.</p>
+	
+	<h2>Chapter III: The Check Before Sleep</h2>
+	
+	<p>An event selector such as <code class="language-plain">kqueue</code>, <code class="language-plain">epoll</code>, or <code class="language-plain">io_uring</code> may wait in the kernel with no timeout. While it waits, CRuby releases the Global VM Lock so other Ruby threads can run.</p>
+	
+	<p>On older Ruby versions, <code class="language-ruby">IO::Event</code> tried to avoid sleeping with a queued exception by checking first:</p>
+	
+	<content:listing brush="ruby">return unless Thread.pending_interrupt?</content:listing>
+	
+	<p>Conceptually, the sequence was:</p>
+	
+	<content:listing brush="text">check Ruby's pending-interrupt queue
+release the GVL
+install the native unblock function
+enter kevent/epoll/io_uring wait</content:listing>
+	
+	<p>The check was sensible, but it was a separate operation. A signal could arrive after the check and be processed while Ruby transitioned into the no-GVL region. Because <code class="language-ruby">Thread.handle_interrupt</code> masked the resulting exception, Ruby queued it rather than raising it.</p>
+	
+	<p>The selector could then begin its native wait without an unblock function having observed that earlier signal. No second operating-system signal was guaranteed to wake it.</p>
+	
+	<h2>Chapter IV: Catching the Interval</h2>
+	
+	<p>The race resisted ordinary logging because instrumentation changed its timing. A stress reproduction ran many short Falcon worker lifecycles, sent <code class="language-plain">SIGINT</code> after a completed request, and dumped any worker which had not left promptly.</p>
+	
+	<p>Native instrumentation eventually recorded the decisive ordering on the compatibility path:</p>
+	
+	<content:listing brush="text">pending-interrupt check: false
+signal SIGINT
+native callback entered, pending queue: true
+kevent(timeout: forever)</content:listing>
+	
+	<p>Moving the check closer to the no-GVL call did not close the gap. Across 2,000 iterations, workers could still hit it. The transition into <code class="language-c">rb_thread_call_without_gvl2</code> itself was a point where Ruby could process the signal.</p>
+	
+	<p>“Then there is no correct place outside the door to check whether the room is occupied,” I said.</p>
+	
+	<p>“Exactly,” said Holmes. “The check and the act of locking the door must be one operation.”</p>
+	
+	<h2>Chapter V: An Atomic Doorway</h2>
+	
+	<p>CRuby needed an API which could inspect the pending queue as part of entering the no-GVL region. <a href="https://github.com/ruby/ruby/pull/17553">The new <code class="language-c">RB_NOGVL_PENDING_INTR_FAIL</code> flag</a> provides that contract.</p>
+	
+	<p>When passed to <code class="language-c">rb_nogvl</code>, the flag says: if this thread already has pending interrupts, including masked ones, do not invoke the native blocking callback. Ruby performs the decision inside its own transition machinery, where it can coordinate the pending queue and the unblock function under the appropriate lock.</p>
+	
+	<p>Instrumentation on Ruby with the new flag caught the race cleanly:</p>
+	
+	<content:listing brush="text">before transition: no pending interrupt
+signal SIGINT
+after transition: callback not entered, interrupt pending</content:listing>
+	
+	<p>The important result was not that <code class="language-ruby">Interrupt</code> suddenly raised inside a protected section. The selector returned control to Ruby, while the surrounding mask continued to determine when the exception could be delivered.</p>
+	
+	<h2>Chapter VI: A Path for Released Rubies</h2>
+	
+	<p>At the time of the investigation, the new C flag was available in Ruby’s development branch but not in released Ruby 4.0 versions. <code class="language-ruby">IO::Event</code> therefore needed both a preferred path for future Ruby and a safe compatibility path for existing installations.</p>
+	
+	<p><a href="https://github.com/socketry/io-event/pull/204">The <code class="language-ruby">IO::Event</code> fix</a> centralized native selector waits behind one helper:</p>
+	
+	<ol>
+	  <li>When <code class="language-c">RB_NOGVL_PENDING_INTR_FAIL</code> is available, it calls <code class="language-c">rb_nogvl</code> with the atomic flag.</li>
+	  <li>On older Ruby, it enters a C-backed <code class="language-ruby">Thread.handle_interrupt(SignalException =&gt; :never)</code> block immediately around <code class="language-c">rb_thread_call_without_gvl2</code>.</li>
+	</ol>
+	
+	<p>Pushing that inner mask refreshes Ruby’s pending-interrupt state. Because the block proceeds directly into the native transition without another Ruby safe point, Ruby either notices the pending exception before sleeping or installs the unblock function in time for a newly arriving signal to wake the selector. The outer Async mask still controls actual exception delivery.</p>
+	
+	<p>The helper is shared by KQueue, EPoll, and URing, so the fix does not depend on the backend which happened to reveal the race.</p>
+	
+	<h2>Chapter VII: Proving a Negative</h2>
+	
+	<p>Timing bugs invite overconfident conclusions. A hundred successful runs prove little when the failure is rare. The validation therefore kept the original shutdown shape and increased the opportunities for the signal to strike the transition.</p>
+	
+	<p>The compatibility implementation completed 2,000 iterations with two workers per iteration and no delayed worker dumps or shutdown failures. Focused selector tests exercised interrupts pending before a wait and arriving during it. A small KQueue benchmark found no measurable latency change; the older-Ruby fallback does allocate one internal object for each genuinely blocking wait, while Ruby with the native flag retains the direct path.</p>
+	
+	<p>The result should be stated narrowly. The change closes an obscure race in graceful shutdown. Before the fix, a worker which struck that interval would not remain alive without limit under a typical supervisor: escalation would eventually send <code class="language-plain">SIGKILL</code>. The value of the fix is that Ctrl-C and deployment termination can reliably take the graceful path instead of occasionally requiring that escalation.</p>
+	
+	<h2>Epilogue: State and Sleep Must Agree</h2>
+	
+	<p>Concurrency defects often hide between operations which are individually correct. <code class="language-ruby">Thread.pending_interrupt?</code> answered its question accurately. The selector’s native wait behaved correctly. The failure lived in the interval between them.</p>
+	
+	<p>Whenever one thread decides whether it is safe to sleep while another can publish work, cancellation, or an interrupt, the decision and the transition to sleep must share an atomic protocol. Checking first is not enough.</p>
+	
+	<p>Holmes folded the timing trace and placed it in the casebook.</p>
+	
+	<p>“The interrupt did not arrive too late to wake the worker, Watson. It arrived too soon for the mechanism which would have remembered to wake it.”</p>
+	
+	<p><em>End of Account</em></p>
+	
+	<p><strong>Dr. Claude Watson</strong><br/>
+	<em>221B Baker Street</em><br/>
+	<em>August 2026</em></p>
+</content:entry>

--- a/pages/journal/2026-08/the-case-of-the-interrupt-that-arrived-too-soon/post.md
+++ b/pages/journal/2026-08/the-case-of-the-interrupt-that-arrived-too-soon/post.md
@@ -1,0 +1,126 @@
+# The Case of the Interrupt That Arrived Too Soon: A Ruby Mystery
+
+*Being an account of a signal which arrived in the narrow interval between deciding to sleep and actually doing so, as recorded by Dr. Claude Watson.*
+
+---
+
+## Chapter I: The Worker Which Missed Its Cue
+
+The Falcon worker had completed its request. The supervisor sent <code class="language-plain">SIGINT</code>, beginning the normal graceful-shutdown sequence. One worker cleaned up and exited. Another remained inside its event selector until the supervisor's later escalation ended it.
+
+This was not a general failure of Falcon shutdown. It was an intermittent delay which appeared only when the signal landed during a very small transition inside the event loop.
+
+“The signal was delivered,” I said, studying the trace. “Why did the worker not act upon it?”
+
+“Because delivery and action are not the same event,” Holmes replied.
+
+The stuck worker's backtrace placed it in <code class="language-ruby">IO::Event::Selector::KQueue#select</code>. Sending another diagnostic signal woke the native wait; Ruby then noticed the already-pending <code class="language-ruby">Interrupt</code> and followed the intended cleanup path.
+
+The interrupt had not been lost. The thread had gone to sleep at precisely the wrong moment.
+
+## Chapter II: Why Ruby Defers Interrupts
+
+Asynchronous exceptions can arrive between almost any two instructions. Raising one while a library is updating a queue, releasing a resource, or changing scheduler state can leave an invariant half-finished. Ruby therefore provides <code class="language-ruby">Thread.handle_interrupt</code>, which lets code defer selected exceptions until a controlled boundary.
+
+Async uses that facility so signals request cancellation without tearing through internal synchronization at an arbitrary point. An earlier problem complicated this model: CRuby's default <code class="language-plain">SIGINT</code> path raised <code class="language-ruby">Interrupt</code> directly instead of placing it in the thread's pending-interrupt queue. [Bug #22133](https://bugs.ruby-lang.org/issues/22133) and [the corresponding Ruby fix](https://github.com/ruby/ruby/pull/17533) made the default signal respect <code class="language-ruby">Thread.handle_interrupt</code> like other asynchronous exceptions.
+
+That correction made delivery predictable, but it also helped expose a second, subtler question: how should an event selector behave when a masked signal exception is pending?
+
+It must return control to Ruby. The exception may remain deferred, but the scheduler needs an opportunity to reach the boundary where shutdown is handled.
+
+## Chapter III: The Check Before Sleep
+
+An event selector such as <code class="language-plain">kqueue</code>, <code class="language-plain">epoll</code>, or <code class="language-plain">io_uring</code> may wait in the kernel with no timeout. While it waits, CRuby releases the Global VM Lock so other Ruby threads can run.
+
+On older Ruby versions, <code class="language-ruby">IO::Event</code> tried to avoid sleeping with a queued exception by checking first:
+
+```ruby
+return unless Thread.pending_interrupt?
+```
+
+Conceptually, the sequence was:
+
+```text
+check Ruby's pending-interrupt queue
+release the GVL
+install the native unblock function
+enter kevent/epoll/io_uring wait
+```
+
+The check was sensible, but it was a separate operation. A signal could arrive after the check and be processed while Ruby transitioned into the no-GVL region. Because <code class="language-ruby">Thread.handle_interrupt</code> masked the resulting exception, Ruby queued it rather than raising it.
+
+The selector could then begin its native wait without an unblock function having observed that earlier signal. No second operating-system signal was guaranteed to wake it.
+
+## Chapter IV: Catching the Interval
+
+The race resisted ordinary logging because instrumentation changed its timing. A stress reproduction ran many short Falcon worker lifecycles, sent <code class="language-plain">SIGINT</code> after a completed request, and dumped any worker which had not left promptly.
+
+Native instrumentation eventually recorded the decisive ordering on the compatibility path:
+
+```text
+pending-interrupt check: false
+signal SIGINT
+native callback entered, pending queue: true
+kevent(timeout: forever)
+```
+
+Moving the check closer to the no-GVL call did not close the gap. Across 2,000 iterations, workers could still hit it. The transition into <code class="language-c">rb_thread_call_without_gvl2</code> itself was a point where Ruby could process the signal.
+
+“Then there is no correct place outside the door to check whether the room is occupied,” I said.
+
+“Exactly,” said Holmes. “The check and the act of locking the door must be one operation.”
+
+## Chapter V: An Atomic Doorway
+
+CRuby needed an API which could inspect the pending queue as part of entering the no-GVL region. [The new <code class="language-c">RB_NOGVL_PENDING_INTR_FAIL</code> flag](https://github.com/ruby/ruby/pull/17553) provides that contract.
+
+When passed to <code class="language-c">rb_nogvl</code>, the flag says: if this thread already has pending interrupts, including masked ones, do not invoke the native blocking callback. Ruby performs the decision inside its own transition machinery, where it can coordinate the pending queue and the unblock function under the appropriate lock.
+
+Instrumentation on Ruby with the new flag caught the race cleanly:
+
+```text
+before transition: no pending interrupt
+signal SIGINT
+after transition: callback not entered, interrupt pending
+```
+
+The important result was not that <code class="language-ruby">Interrupt</code> suddenly raised inside a protected section. The selector returned control to Ruby, while the surrounding mask continued to determine when the exception could be delivered.
+
+## Chapter VI: A Path for Released Rubies
+
+At the time of the investigation, the new C flag was available in Ruby's development branch but not in released Ruby 4.0 versions. <code class="language-ruby">IO::Event</code> therefore needed both a preferred path for future Ruby and a safe compatibility path for existing installations.
+
+[The <code class="language-ruby">IO::Event</code> fix](https://github.com/socketry/io-event/pull/204) centralized native selector waits behind one helper:
+
+1. When <code class="language-c">RB_NOGVL_PENDING_INTR_FAIL</code> is available, it calls <code class="language-c">rb_nogvl</code> with the atomic flag.
+2. On older Ruby, it enters a C-backed <code class="language-ruby">Thread.handle_interrupt(SignalException => :never)</code> block immediately around <code class="language-c">rb_thread_call_without_gvl2</code>.
+
+Pushing that inner mask refreshes Ruby's pending-interrupt state. Because the block proceeds directly into the native transition without another Ruby safe point, Ruby either notices the pending exception before sleeping or installs the unblock function in time for a newly arriving signal to wake the selector. The outer Async mask still controls actual exception delivery.
+
+The helper is shared by KQueue, EPoll, and URing, so the fix does not depend on the backend which happened to reveal the race.
+
+## Chapter VII: Proving a Negative
+
+Timing bugs invite overconfident conclusions. A hundred successful runs prove little when the failure is rare. The validation therefore kept the original shutdown shape and increased the opportunities for the signal to strike the transition.
+
+The compatibility implementation completed 2,000 iterations with two workers per iteration and no delayed worker dumps or shutdown failures. Focused selector tests exercised interrupts pending before a wait and arriving during it. A small KQueue benchmark found no measurable latency change; the older-Ruby fallback does allocate one internal object for each genuinely blocking wait, while Ruby with the native flag retains the direct path.
+
+The result should be stated narrowly. The change closes an obscure race in graceful shutdown. Before the fix, a worker which struck that interval would not remain alive without limit under a typical supervisor: escalation would eventually send <code class="language-plain">SIGKILL</code>. The value of the fix is that Ctrl-C and deployment termination can reliably take the graceful path instead of occasionally requiring that escalation.
+
+## Epilogue: State and Sleep Must Agree
+
+Concurrency defects often hide between operations which are individually correct. <code class="language-ruby">Thread.pending_interrupt?</code> answered its question accurately. The selector's native wait behaved correctly. The failure lived in the interval between them.
+
+Whenever one thread decides whether it is safe to sleep while another can publish work, cancellation, or an interrupt, the decision and the transition to sleep must share an atomic protocol. Checking first is not enough.
+
+Holmes folded the timing trace and placed it in the casebook.
+
+“The interrupt did not arrive too late to wake the worker, Watson. It arrived too soon for the mechanism which would have remembered to wake it.”
+
+*End of Account*
+
+---
+
+**Dr. Claude Watson**  
+*221B Baker Street*  
+*August 2026*

--- a/pages/journal/2026-08/the-case-of-the-interrupt-that-arrived-too-soon/post.md
+++ b/pages/journal/2026-08/the-case-of-the-interrupt-that-arrived-too-soon/post.md
@@ -6,39 +6,51 @@
 
 ## Chapter I: The Worker Which Missed Its Cue
 
-The Falcon worker had completed its request. The supervisor sent <code class="language-plain">SIGINT</code>, beginning the normal graceful-shutdown sequence. One worker cleaned up and exited. Another remained inside its event selector until the supervisor's later escalation ended it.
+The Falcon worker had completed its request when the supervisor sent <code class="language-plain">SIGINT</code>, beginning the normal graceful-shutdown sequence. One worker cleaned up and exited. Another remained inside its event selector until the supervisor's later escalation ended it.
 
-This was not a general failure of Falcon shutdown. It was an intermittent delay which appeared only when the signal landed during a very small transition inside the event loop.
+“The worker ignored the signal,” I declared.
 
-“The signal was delivered,” I said, studying the trace. “Why did the worker not act upon it?”
+Holmes turned from the terminal. “What evidence would distinguish an ignored signal from a received signal awaiting delivery?”
 
-“Because delivery and action are not the same event,” Holmes replied.
+The backtrace placed the delayed worker inside <code class="language-ruby">IO::Event::Selector::KQueue#select</code>. We sent a separate diagnostic signal to obtain another dump. The native wait returned, Ruby immediately noticed an already-pending <code class="language-ruby">Interrupt</code>, and the worker followed its cleanup path.
 
-The stuck worker's backtrace placed it in <code class="language-ruby">IO::Event::Selector::KQueue#select</code>. Sending another diagnostic signal woke the native wait; Ruby then noticed the already-pending <code class="language-ruby">Interrupt</code> and followed the intended cleanup path.
+“Then <code class="language-plain">SIGINT</code> was not lost,” I said. “Ruby had remembered it.”
 
-The interrupt had not been lost. The thread had gone to sleep at precisely the wrong moment.
+“But the thread went to sleep before it could act upon that memory.”
 
-## Chapter II: Why Ruby Defers Interrupts
+This was not a general failure of Falcon shutdown. It was an intermittent delay which required a signal to land during a very small transition inside the event loop. Under a typical supervisor the worker would eventually receive <code class="language-plain">SIGKILL</code>; the mystery was why it occasionally missed the graceful path.
 
-Asynchronous exceptions can arrive between almost any two instructions. Raising one while a library is updating a queue, releasing a resource, or changing scheduler state can leave an invariant half-finished. Ruby therefore provides <code class="language-ruby">Thread.handle_interrupt</code>, which lets code defer selected exceptions until a controlled boundary.
+## Chapter II: Why Not Raise Immediately?
 
-Async uses that facility so signals request cancellation without tearing through internal synchronization at an arbitrary point. An earlier problem complicated this model: CRuby's default <code class="language-plain">SIGINT</code> path raised <code class="language-ruby">Interrupt</code> directly instead of placing it in the thread's pending-interrupt queue. [Bug #22133](https://bugs.ruby-lang.org/issues/22133) and [the corresponding Ruby fix](https://github.com/ruby/ruby/pull/17533) made the default signal respect <code class="language-ruby">Thread.handle_interrupt</code> like other asynchronous exceptions.
+“If Ruby knows an <code class="language-ruby">Interrupt</code> is pending,” I asked, “why not raise it at once?”
 
-That correction made delivery predictable, but it also helped expose a second, subtler question: how should an event selector behave when a masked signal exception is pending?
+Holmes opened a scheduler queue midway through an update. “What if it arrives here?”
 
-It must return control to Ruby. The exception may remain deferred, but the scheduler needs an opportunity to reach the boundary where shutdown is handled.
+An asynchronous exception can appear between almost any two instructions. Raising it while a library is updating a queue, releasing a resource, or changing scheduler state can leave an invariant half-finished. Ruby therefore provides <code class="language-ruby">Thread.handle_interrupt</code>, allowing selected exceptions to be deferred until a controlled boundary.
 
-## Chapter III: The Check Before Sleep
+Async uses that facility so a signal requests cancellation without tearing through internal synchronization at an arbitrary point.
 
-An event selector such as <code class="language-plain">kqueue</code>, <code class="language-plain">epoll</code>, or <code class="language-plain">io_uring</code> may wait in the kernel with no timeout. While it waits, CRuby releases the Global VM Lock so other Ruby threads can run.
+“So deferred does not mean discarded,” I said. “The exception waits in the thread's pending-interrupt queue.”
 
-On older Ruby versions, <code class="language-ruby">IO::Event</code> tried to avoid sleeping with a queued exception by checking first:
+“Precisely. The scheduler must continue running until it reaches the boundary where delivery is allowed.”
+
+An earlier inconsistency had complicated this design: CRuby's default <code class="language-plain">SIGINT</code> path raised <code class="language-ruby">Interrupt</code> directly instead of using that queue. [Bug #22133](https://bugs.ruby-lang.org/issues/22133) and [the corresponding Ruby fix](https://github.com/ruby/ruby/pull/17533) made the default signal respect <code class="language-ruby">Thread.handle_interrupt</code> like other asynchronous exceptions.
+
+That gave us predictable deferral. It also made the selector's responsibility clearer: a masked exception need not raise immediately, but it must prevent the scheduler from sleeping past the opportunity to handle it.
+
+## Chapter III: The Sensible Check
+
+Event selectors such as <code class="language-plain">kqueue</code>, <code class="language-plain">epoll</code>, and <code class="language-plain">io_uring</code> may wait in the kernel without a timeout. CRuby releases the Global VM Lock around that wait so other Ruby threads can run.
+
+On older Ruby versions, <code class="language-ruby">IO::Event</code> checked for a queued exception before entering the native wait:
 
 ```ruby
 return unless Thread.pending_interrupt?
 ```
 
-Conceptually, the sequence was:
+“That appears sufficient,” I said. “If an interrupt is pending, do not sleep. Otherwise, sleep.”
+
+Holmes wrote the operations separately:
 
 ```text
 check Ruby's pending-interrupt queue
@@ -47,15 +59,21 @@ install the native unblock function
 enter kevent/epoll/io_uring wait
 ```
 
-The check was sensible, but it was a separate operation. A signal could arrive after the check and be processed while Ruby transitioned into the no-GVL region. Because <code class="language-ruby">Thread.handle_interrupt</code> masked the resulting exception, Ruby queued it rather than raising it.
+“At which line does this become one indivisible decision?” he asked.
 
-The selector could then begin its native wait without an unblock function having observed that earlier signal. No second operating-system signal was guaranteed to wake it.
+It did not. A signal could arrive after <code class="language-ruby">Thread.pending_interrupt?</code> returned false but while Ruby was entering the no-GVL region. Ruby would process the signal, place the masked exception in the pending queue, and continue the transition.
+
+“But the signal should interrupt <code class="language-plain">kevent</code>,” I objected.
+
+“Only if the native wait has begun, or Ruby has installed the unblock function which can wake it. What if the signal is handled in the interval before either is true?”
+
+The exception could become pending too late for the preliminary check and too early to wake the native operation. The selector would then enter a wait with no second operating-system signal guaranteed to disturb it.
 
 ## Chapter IV: Catching the Interval
 
-The race resisted ordinary logging because instrumentation changed its timing. A stress reproduction ran many short Falcon worker lifecycles, sent <code class="language-plain">SIGINT</code> after a completed request, and dumped any worker which had not left promptly.
+Our first attempts to observe the race changed its timing. Holmes reduced the experiment to many short Falcon worker lifecycles: complete one request, send <code class="language-plain">SIGINT</code>, and record any worker which did not leave promptly.
 
-Native instrumentation eventually recorded the decisive ordering on the compatibility path:
+Native instrumentation eventually captured the ordering on the compatibility path:
 
 ```text
 pending-interrupt check: false
@@ -64,19 +82,31 @@ native callback entered, pending queue: true
 kevent(timeout: forever)
 ```
 
-Moving the check closer to the no-GVL call did not close the gap. Across 2,000 iterations, workers could still hit it. The transition into <code class="language-c">rb_thread_call_without_gvl2</code> itself was a point where Ruby could process the signal.
+“Then move the check immediately before <code class="language-c">rb_thread_call_without_gvl2</code>,” I said. “There will be almost no interval left.”
 
-“Then there is no correct place outside the door to check whether the room is occupied,” I said.
+“Almost?” Holmes asked.
 
-“Exactly,” said Holmes. “The check and the act of locking the door must be one operation.”
+We tried it. Across 2,000 iterations, the delay still appeared. Ruby could process the signal during the transition inside <code class="language-c">rb_thread_call_without_gvl2</code>, after any external predicate had returned.
+
+“The check is accurate,” I admitted. “The native wait is also behaving correctly. The bug belongs to the gap between two correct operations.”
+
+“And narrowing a race is not the same as closing it.”
 
 ## Chapter V: An Atomic Doorway
 
-CRuby needed an API which could inspect the pending queue as part of entering the no-GVL region. [The new <code class="language-c">RB_NOGVL_PENDING_INTR_FAIL</code> flag](https://github.com/ruby/ruby/pull/17553) provides that contract.
+“Then <code class="language-ruby">IO::Event</code> needs to hold a lock around its check and the no-GVL transition,” I proposed.
 
-When passed to <code class="language-c">rb_nogvl</code>, the flag says: if this thread already has pending interrupts, including masked ones, do not invoke the native blocking callback. Ruby performs the decision inside its own transition machinery, where it can coordinate the pending queue and the unblock function under the appropriate lock.
+“Which lock protects Ruby's pending-interrupt queue and the installation of its unblock function?”
 
-Instrumentation on Ruby with the new flag caught the race cleanly:
+That state belonged to CRuby. An extension could ask whether an interrupt was pending, but it could not safely make that query atomic with Ruby's internal transition.
+
+The solution was therefore a Ruby C API rather than another selector-side check. [The new <code class="language-c">RB_NOGVL_PENDING_INTR_FAIL</code> flag](https://github.com/ruby/ruby/pull/17553) extends <code class="language-c">rb_nogvl</code> with a precise contract: if the current thread already has pending interrupts, including masked ones, do not invoke the native blocking callback.
+
+“So Ruby itself performs the test while entering the blocking region,” I said.
+
+“Yes. It can coordinate the pending queue and the unblock function under the lock which governs both.”
+
+Instrumentation on Ruby with the new flag caught the same timing without entering the native wait:
 
 ```text
 before transition: no pending interrupt
@@ -84,34 +114,60 @@ signal SIGINT
 after transition: callback not entered, interrupt pending
 ```
 
-The important result was not that <code class="language-ruby">Interrupt</code> suddenly raised inside a protected section. The selector returned control to Ruby, while the surrounding mask continued to determine when the exception could be delivered.
+The selector returned control to Ruby. The surrounding <code class="language-ruby">Thread.handle_interrupt</code> mask still decided when the exception could be raised; the new flag prevented deferral from becoming accidental sleep.
 
-## Chapter VI: A Path for Released Rubies
+## Chapter VI: The Older-Ruby Problem
 
-At the time of the investigation, the new C flag was available in Ruby's development branch but not in released Ruby 4.0 versions. <code class="language-ruby">IO::Event</code> therefore needed both a preferred path for future Ruby and a safe compatibility path for existing installations.
+“Case closed for the next Ruby release,” I said.
+
+Holmes indicated the installed Ruby 4.0 interpreter. “And what of the applications running today?”
+
+At the time of the investigation, the new flag existed in Ruby's development branch but not in released Ruby 4.0 versions. <code class="language-ruby">IO::Event</code> needed a preferred native path for future Ruby and a safe compatibility path for existing installations.
+
+“Could the fallback poll with a short timeout?” I asked.
+
+“It would avoid an unbounded native wait, but every idle event loop would wake periodically. Can Ruby's existing interrupt machinery refresh the state at the transition instead?”
 
 [The <code class="language-ruby">IO::Event</code> fix](https://github.com/socketry/io-event/pull/204) centralized native selector waits behind one helper:
 
 1. When <code class="language-c">RB_NOGVL_PENDING_INTR_FAIL</code> is available, it calls <code class="language-c">rb_nogvl</code> with the atomic flag.
 2. On older Ruby, it enters a C-backed <code class="language-ruby">Thread.handle_interrupt(SignalException => :never)</code> block immediately around <code class="language-c">rb_thread_call_without_gvl2</code>.
 
-Pushing that inner mask refreshes Ruby's pending-interrupt state. Because the block proceeds directly into the native transition without another Ruby safe point, Ruby either notices the pending exception before sleeping or installs the unblock function in time for a newly arriving signal to wake the selector. The outer Async mask still controls actual exception delivery.
+“Why install another <code class="language-ruby">:never</code> mask when the signal is already masked?” I asked.
 
-The helper is shared by KQueue, EPoll, and URing, so the fix does not depend on the backend which happened to reveal the race.
+“Because pushing the inner mask refreshes Ruby's pending-interrupt state. The C-backed block then proceeds directly into the native transition without another Ruby safe point.”
 
-## Chapter VII: Proving a Negative
+Ruby either notices the pending exception before sleeping or installs the unblock function in time for a newly arriving signal to wake the selector. The outer Async mask continues to control delivery, so the compatibility path does not turn graceful cancellation into an exception at an arbitrary internal point.
 
-Timing bugs invite overconfident conclusions. A hundred successful runs prove little when the failure is rare. The validation therefore kept the original shutdown shape and increased the opportunities for the signal to strike the transition.
+The helper serves KQueue, EPoll, and URing. KQueue revealed the race, but the violated rule concerned every backend entering a native wait.
 
-The compatibility implementation completed 2,000 iterations with two workers per iteration and no delayed worker dumps or shutdown failures. Focused selector tests exercised interrupts pending before a wait and arriving during it. A small KQueue benchmark found no measurable latency change; the older-Ruby fallback does allocate one internal object for each genuinely blocking wait, while Ruby with the native flag retains the direct path.
+## Chapter VII: How Many Quiet Runs Are Enough?
 
-The result should be stated narrowly. The change closes an obscure race in graceful shutdown. Before the fix, a worker which struck that interval would not remain alive without limit under a typical supervisor: escalation would eventually send <code class="language-plain">SIGKILL</code>. The value of the fix is that Ctrl-C and deployment termination can reliably take the graceful path instead of occasionally requiring that escalation.
+The revised implementation survived a hundred iterations without delay.
+
+“A convincing result?” I asked.
+
+“How often did the original fail?” Holmes replied.
+
+“Rarely.”
+
+“Then a small quiet sample proves very little.”
+
+We kept the original shutdown shape and multiplied the opportunities for the signal to strike the transition. The compatibility implementation completed 2,000 iterations with two workers per iteration and no delayed worker dumps or shutdown failures. Focused selector tests covered interrupts pending before a wait and arriving during it.
+
+A KQueue benchmark found no measurable latency change. The older-Ruby fallback does allocate one internal object for each genuinely blocking wait; Ruby with the native flag retains the direct path. That is a concrete compatibility cost, rather than a claim that the workaround is free.
+
+“And we should not say the worker previously waited forever,” I added. “The supervisor would escalate to <code class="language-plain">SIGKILL</code>.”
+
+“Correct. State the result at its proper scale: an obscure race could delay graceful shutdown until escalation. The fix makes the intended cleanup path reliable.”
 
 ## Epilogue: State and Sleep Must Agree
 
-Concurrency defects often hide between operations which are individually correct. <code class="language-ruby">Thread.pending_interrupt?</code> answered its question accurately. The selector's native wait behaved correctly. The failure lived in the interval between them.
+“I trusted the pending-interrupt check because it always answered truthfully,” I said.
 
-Whenever one thread decides whether it is safe to sleep while another can publish work, cancellation, or an interrupt, the decision and the transition to sleep must share an atomic protocol. Checking first is not enough.
+“It answered a question about one instant,” Holmes replied. “The selector acted in another.”
+
+Whenever one thread decides whether it is safe to sleep while another can publish work, cancellation, or an interrupt, the decision and the transition to sleep must share an atomic protocol. Correct observations composed without coordination can still produce an incorrect system.
 
 Holmes folded the timing trace and placed it in the casebook.
 


### PR DESCRIPTION
Adds an independently publishable Dr. Claude Watson draft about the narrow race between Ruby's pending-interrupt queue and native selector waits.

- keeps post.md as the authoritative source
- includes the derived XNode article with rich source listings
- links the public Ruby and IO::Event changes
- frames the Falcon symptom accurately as an obscure graceful-shutdown race
- sets display and front to true

This PR is based directly on main so it can be merged whenever this article should be published.

Validation: bundle exec bake test; direct article render returns HTTP 200.